### PR TITLE
Extended yum-cron configuration (Jens Van Deynse)

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,49 +17,50 @@ No specific requirements
 
 ## Role Variables
 
-| Variable                                  | Default         | Comments (type)                                                                                                       |
-| :---                                      | :---            | :---                                                                                                                  |
-| `rhbase_enable_repos`                     | []              | List of dicts specifying repositories to be enabled. See below for details.                                           |
-| `rhbase_firewall_allow_ports`             | []              | List of ports to be allowed to pass through the firewall, e.g. 80/tcp, 53/udp, etc.                                   |
-| `rhbase_firewall_allow_services`          | []              | List of services to be allowed to pass through the firewall, e.g. http, dns, etc.(1)                                  |
-| `rhbase_firewall_interfaces`              | []              | List of network interfaces to be added to the public zone of the firewall ruleset.                                    |
-| `rhbase_hosts_entry`                      | true            | When set, an entry is added to `/etc/hosts` with the machine's host name. This speeds up gathering facts.             |
-| `rhbase_install_packages`                 | []              | List of packages that should be installed. URLs are also allowed.                                                     |
-| `rhbase_motd`                             | false           | When set, a custom `/etc/motd` is installed with info about the host name and IP addresses.                           |
-| `rhbase_override_firewalld_zones`         | false           | When set, allows NetworkManager to override firewall zones set by the administrator(2).                               |
-| `rhbase_remove_packages`                  | []              | List of packages that should **not** be installed                                                                     |
-| `rhbase_repo_exclude_from_update`         | []              | List of packages to be excluded from an update. Wildcards allowed, e.g. `kernel*`.                                    |
-| `rhbase_repo_exclude`                     | []              | List of repositories that should be disabled in yum/dnf.conf                                                          |
-| `rhbase_repo_gpgcheck`                    | false           | When set, GPG checks will be performed when installing packages.                                                      |
+| Variable                                  | Default         | Comments (type)                                              |
+| :---------------------------------------- | :-------------- | :----------------------------------------------------------- |
+| `rhbase_enable_repos`                     | []              | List of dicts specifying repositories to be enabled. See below for details. |
+| `rhbase_firewall_allow_ports`             | []              | List of ports to be allowed to pass through the firewall, e.g. 80/tcp, 53/udp, etc. |
+| `rhbase_firewall_allow_services`          | []              | List of services to be allowed to pass through the firewall, e.g. http, dns, etc.(1) |
+| `rhbase_firewall_interfaces`              | []              | List of network interfaces to be added to the public zone of the firewall ruleset. |
+| `rhbase_hosts_entry`                      | true            | When set, an entry is added to `/etc/hosts` with the machine's host name. This speeds up gathering facts. |
+| `rhbase_install_packages`                 | []              | List of packages that should be installed. URLs are also allowed. |
+| `rhbase_motd`                             | false           | When set, a custom `/etc/motd` is installed with info about the host name and IP addresses. |
+| `rhbase_override_firewalld_zones`         | false           | When set, allows NetworkManager to override firewall zones set by the administrator(2). |
+| `rhbase_remove_packages`                  | []              | List of packages that should **not** be installed            |
+| `rhbase_repo_exclude_from_update`         | []              | List of packages to be excluded from an update. Wildcards allowed, e.g. `kernel*`. |
+| `rhbase_repo_exclude`                     | []              | List of repositories that should be disabled in yum/dnf.conf |
+| `rhbase_repo_gpgcheck`                    | false           | When set, GPG checks will be performed when installing packages. |
 | `rhbase_repo_installonly_limit`           | 3               | The maximum number of versions of a package (e.g. kernel) that can be installed simultaneously. Should be at least 2. |
-| `rhbase_repo_remove_dependencies`         | true            | When set, dependencies that become unused after removing a package will be removed as well.                           |
-| `rhbase_repositories`                     | []              | List of RPM packages (including URLs) that install external repositories (e.g. `epel-release`).                       |
-| `rhbase_selinux_state`                    | enforcing       | The default SELinux state for the system. Just [leave this as is](http://stopdisablingselinux.com/).                  |
-| `rhbase_selinux_booleans`                 | []              | List of SELinux booleans to be set to on, e.g. httpd_can_network_connect                                              |
-| `rhbase_ssh_key`                          | -               | The public SSH key for the admin user that allows her to log in without a password. The user should exist.            |
-| `rhbase_ssh_user`                         | -               | The name of the user that will manage this machine. The SSH key will be installed into the user's home directory.(3)  |
-| `rhbase_start_services`                   | []              | List of services that should be running and enabled.                                                                  |
-| `rhbase_stop_services`                    | []              | List of services that should **not** be running                                                                       |
-| `rhbase_tz`                               | :/etc/localtime | Sets the `$TZ` environment variable (4)                                                                               |
-| `rhbase_update`                           | false           | When set, a package update will be performed.                                                                         |
-| `rhbase_user_groups`                      | []              | List of user groups that should be present.                                                                           |
-| `rhbase_users`                            | []              | List of dicts specifying users that should be present. See below for an example.                                      |
-| `rhbase_yum_cron_update_level`            | default         | What kind of update to use on the daily cron (default, security, security-severity:Critical, minimal, ...).           |
-| `rhbase_yum_cron_update_messages`         | yes             | Whether to display or send messages when the daily yum-cron has executed a task (yes/no).                             |
-| `rhbase_yum_cron_download_updates`        | yes             | Whether to download updates when available using the daily yum-cron (yes/no).                                         |
-| `rhbase_yum_cron_install_updates`         | yes             | Whether to install updates when available using the daily yum-cron (yes/no).                                          |  
-| `rhbase_yum_cron_sleep_time`              | 360             | Maximum of amount of random sleep for the daily yum-cron in minutes.                                                  |
-| `rhbase_yum_cron_system_name`             | hostname        | Name to use for this system when emitting messages.                                                                   |
-| `rhbase_yum_cron_message_protocol`        | stdio           | Way to send messages when messages are available in the daily yum-cron (stdio/email).                                 |
-| `rhbase_yum_cron_email_from`              | root@localhost  | The address to send email messages from.                                                                              |
-| `rhbase_yum_cron_email_to`                | root            | The address to send email messages to.                                                                                |
-| `rhbase_yum_cron_email_host`              | localhost       | The host to connect with to send email messages.                                                                      |
-| `rhbase_yum_cron_hourly_update_level`     | minimal         | What kind of update to use on the hourly cron (default, security, security-severity:Critical, minimal, ...).          |
-| `rhbase_yum_cron_hourly_update_messages`  | yes             | Whether to display or send messages when the hourly yum-cron has executed a task (yes/no).                            |
-| `rhbase_yum_cron_hourly_download_updates` | yes             | Whether to download updates when available using the hourly yum-cron (yes/no).                                        |
-| `rhbase_yum_cron_hourly_install_updates`  | no              | Whether to install updates when available using the hourly yum-cron (yes/no)                                          |
-| `rhbase_yum_cron_hourly_sleep_time`       | 15              | Maximum of amount of random sleep for the hourly yum-cron in minutes.                                                 |
-| `rhbase_yum_cron_hourly_message_protocol` | stdio           | Way to send messages when messages are available in the hourly yum-cron (stdio/email).                                |
+| `rhbase_repo_remove_dependencies`         | true            | When set, dependencies that become unused after removing a package will be removed as well. |
+| `rhbase_repositories`                     | []              | List of RPM packages (including URLs) that install external repositories (e.g. `epel-release`). |
+| `rhbase_selinux_state`                    | enforcing       | The default SELinux state for the system. Just [leave this as is](http://stopdisablingselinux.com/). |
+| `rhbase_selinux_booleans`                 | []              | List of SELinux booleans to be set to on, e.g. httpd_can_network_connect |
+| `rhbase_ssh_key`                          | -               | The public SSH key for the admin user that allows her to log in without a password. The user should exist. |
+| `rhbase_ssh_user`                         | -               | The name of the user that will manage this machine. The SSH key will be installed into the user's home directory.(3) |
+| `rhbase_start_services`                   | []              | List of services that should be running and enabled.         |
+| `rhbase_stop_services`                    | []              | List of services that should **not** be running              |
+| `rhbase_tz`                               | :/etc/localtime | Sets the `$TZ` environment variable (4)                      |
+| `rhbase_update`                           | false           | When set, a package update will be performed.                |
+| `rhbase_user_groups`                      | []              | List of user groups that should be present.                  |
+| `rhbase_users`                            | []              | List of dicts specifying users that should be present. See below for an example. |
+| `rhbase_automatic_updates`                | no              | Whether to enable automatic updates, if yes, this installs and configures yum-cron. |
+| `rhbase_yum_cron_update_level`            | default         | What kind of update to use on the daily cron (default, security, security-severity:Critical, minimal, ...). |
+| `rhbase_yum_cron_update_messages`         | yes             | Whether to display or send messages when the daily yum-cron has executed a task (yes/no). |
+| `rhbase_yum_cron_download_updates`        | yes             | Whether to download updates when available using the daily yum-cron (yes/no). |
+| `rhbase_yum_cron_install_updates`         | yes             | Whether to install updates when available using the daily yum-cron (yes/no). |
+| `rhbase_yum_cron_sleep_time`              | 360             | Maximum of amount of random sleep for the daily yum-cron in minutes. |
+| `rhbase_yum_cron_system_name`             | hostname        | Name to use for this system when emitting messages.          |
+| `rhbase_yum_cron_message_protocol`        | stdio           | Way to send messages when messages are available in the daily yum-cron (stdio/email). |
+| `rhbase_yum_cron_email_from`              | root@localhost  | The address to send email messages from.                     |
+| `rhbase_yum_cron_email_to`                | root            | The address to send email messages to.                       |
+| `rhbase_yum_cron_email_host`              | localhost       | The host to connect with to send email messages.             |
+| `rhbase_yum_cron_hourly_update_level`     | minimal         | What kind of update to use on the hourly cron (default, security, security-severity:Critical, minimal, ...). |
+| `rhbase_yum_cron_hourly_update_messages`  | yes             | Whether to display or send messages when the hourly yum-cron has executed a task (yes/no). |
+| `rhbase_yum_cron_hourly_download_updates` | yes             | Whether to download updates when available using the hourly yum-cron (yes/no). |
+| `rhbase_yum_cron_hourly_install_updates`  | no              | Whether to install updates when available using the hourly yum-cron (yes/no) |
+| `rhbase_yum_cron_hourly_sleep_time`       | 15              | Maximum of amount of random sleep for the hourly yum-cron in minutes. |
+| `rhbase_yum_cron_hourly_message_protocol` | stdio           | Way to send messages when messages are available in the hourly yum-cron (stdio/email). |
 
 
 **Remarks:**

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ No specific requirements
 | `rhbase_update`                           | false           | When set, a package update will be performed.                |
 | `rhbase_user_groups`                      | []              | List of user groups that should be present.                  |
 | `rhbase_users`                            | []              | List of dicts specifying users that should be present. See below for an example. |
-| `rhbase_automatic_updates`                | no              | Whether to enable automatic updates, if yes, this installs and configures yum-cron. |
+| `rhbase_automatic_updates`                | false           | Whether to enable automatic updates, if yes, this installs and configures yum-cron. |
 | `rhbase_yum_cron_update_level`            | default         | What kind of update to use on the daily cron (default, security, security-severity:Critical, minimal, ...). |
 | `rhbase_yum_cron_update_messages`         | yes             | Whether to display or send messages when the daily yum-cron has executed a task (yes/no). |
 | `rhbase_yum_cron_download_updates`        | yes             | Whether to download updates when available using the daily yum-cron (yes/no). |

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -33,3 +33,21 @@ rhbase_selinux_booleans: []
 # Users
 rhbase_users: []
 rhbase_user_groups: []
+
+# Yum-cron
+rhbase_yum_cron_update_level: default
+rhbase_yum_cron_update_messages: yes
+rhbase_yum_cron_download_updates: yes
+rhbase_yum_cron_install_updates: yes
+rhbase_yum_cron_sleep_time: 360
+rhbase_yum_cron_system_name: "{{ ansible_hostname }}"
+rhbase_yum_cron_message_protocol: stdio
+rhbase_yum_cron_email_from: root@localhost
+rhbase_yum_cron_email_to: root
+rhbase_yum_cron_email_host: localhost
+rhbase_yum_cron_hourly_update_level: minimal
+rhbase_yum_cron_hourly_update_messages: yes
+rhbase_yum_cron_hourly_download_updates: yes
+rhbase_yum_cron_hourly_install_updates: no
+rhbase_yum_cron_hourly_sleep_time: 15
+rhbase_yum_cron_hourly_message_protocol: stdio

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -35,7 +35,7 @@ rhbase_users: []
 rhbase_user_groups: []
 
 # Yum-cron
-rhbase_automatic_updates: no
+rhbase_automatic_updates: false
 rhbase_yum_cron_update_level: default
 rhbase_yum_cron_update_messages: yes
 rhbase_yum_cron_download_updates: yes

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -35,6 +35,7 @@ rhbase_users: []
 rhbase_user_groups: []
 
 # Yum-cron
+rhbase_automatic_updates: no
 rhbase_yum_cron_update_level: default
 rhbase_yum_cron_update_messages: yes
 rhbase_yum_cron_download_updates: yes

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -10,3 +10,9 @@
   service:
     name: firewalld
     state: restarted
+
+- name: restart yum-cron
+  service:
+    name: yum-cron
+    state: restarted
+

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -13,4 +13,5 @@
 - include_tasks: security.yml # Security settings
 - include_tasks: users.yml    # Create users
 - include_tasks: admin.yml    # Admin user (a.o. SSH key)
+- include_tasks: yum-cron.yml # Automatic updates
 

--- a/tasks/yum-cron.yml
+++ b/tasks/yum-cron.yml
@@ -6,7 +6,7 @@
   yum:
     name: yum-cron
     state: present
-  when: rhbase_automatic_updates == yes
+  when: rhbase_automatic_updates == true
 
 - name: Yum-cron | Install yum-cron configuration
   template:
@@ -19,11 +19,11 @@
     - yum-cron.conf
     - yum-cron-hourly.conf
   notify: restart yum-cron
-  when: rh_automatic_updates == yes
+  when: rhbase_automatic_updates == true
 
 - name: Yum-cron | Start yum-cron service
   service:
     name: yum-cron
     state: started
     enabled: yes
-  when: rh_automatic_updates == yes
+  when: rhbase_automatic_updates == true

--- a/tasks/yum-cron.yml
+++ b/tasks/yum-cron.yml
@@ -1,0 +1,26 @@
+# roles/rhbase/tasks/yum-cron.yml
+#
+# Settings regarding yum-cron
+---
+- name: Yum-cron | Install yum-cron
+  yum:
+    name: yum-cron
+    state: present
+
+- name: Yum-cron | Install yum-cron configuration
+  template:
+    src: "{{ item }}.j2"
+    dest: "/etc/yum/{{ item }}"
+    owner: root
+    group: root
+    mode: 0644
+  with_items:
+    - yum-cron.conf
+    - yum-cron-hourly.conf
+  notify: restart yum-cron
+
+- name: Yum-cron | Start yum-cron service
+  service:
+    name: yum-cron
+    state: started
+    enabled: yes

--- a/tasks/yum-cron.yml
+++ b/tasks/yum-cron.yml
@@ -6,6 +6,7 @@
   yum:
     name: yum-cron
     state: present
+  when: rhbase_automatic_updates == yes
 
 - name: Yum-cron | Install yum-cron configuration
   template:
@@ -18,9 +19,11 @@
     - yum-cron.conf
     - yum-cron-hourly.conf
   notify: restart yum-cron
+  when: rh_automatic_updates == yes
 
 - name: Yum-cron | Start yum-cron service
   service:
     name: yum-cron
     state: started
     enabled: yes
+  when: rh_automatic_updates == yes

--- a/templates/yum-cron-hourly.conf.j2
+++ b/templates/yum-cron-hourly.conf.j2
@@ -1,0 +1,81 @@
+# {{ ansible_managed }}
+[commands]
+#  What kind of update to use:
+# default                            = yum upgrade
+# security                           = yum --security upgrade
+# security-severity:Critical         = yum --sec-severity=Critical upgrade
+# minimal                            = yum --bugfix update-minimal
+# minimal-security                   = yum --security update-minimal
+# minimal-security-severity:Critical =  --sec-severity=Critical update-minimal
+update_cmd = {{ rhbase_yum_cron_hourly_update_level }}
+
+# Whether a message should emitted when updates are available.
+update_messages = {{ rhbase_yum_cron_hourly_update_messages }}
+
+# Whether updates should be downloaded when they are available. Note
+# that updates_messages must also be yes for updates to be downloaded.
+download_updates = {{ rhbase_yum_cron_hourly_download_updates }}
+
+# Whether updates should be applied when they are available.  Note
+# that both update_messages and download_updates must also be yes for
+# the update to be applied
+apply_updates = {{ rhbase_yum_cron_hourly_install_updates }}
+
+# Maximum amout of time to randomly sleep, in minutes.  The program
+# will sleep for a random amount of time between 0 and random_sleep
+# minutes before running.  This is useful for e.g. staggering the
+# times that multiple systems will access update servers.  If
+# random_sleep is 0 or negative, the program will run immediately.
+random_sleep = {{ rhbase_yum_cron_hourly_sleep_time }}
+
+
+[emitters]
+# Name to use for this system in messages that are emitted.  If
+# system_name is None, the hostname will be used.
+system_name = {{ rhbase_yum_cron_system_name }}
+
+# How to send messages.  Valid options are stdio and email.  If
+# emit_via includes stdio, messages will be sent to stdout; this is useful
+# to have cron send the messages.  If emit_via includes email, this
+# program will send email itself according to the configured options.
+# If emit_via is None or left blank, no messages will be sent.
+emit_via = {{ rhbase_yum_cron_hourly_message_protocol }}
+
+# The width, in characters, that messages that are emitted should be
+# formatted to.
+output_width = 80
+
+
+[email]
+# The address to send email messages from.
+# NOTE: 'localhost' will be replaced with the value of system_name.
+email_from = {{ rhbase_yum_cron_email_from }}
+
+# List of addresses to send messages to.
+email_to = {{ rhbase_yum_cron_email_to }}
+
+# Name of the host to connect to to send email messages.
+email_host = {{ rhbase_yum_cron_email_host }}
+
+
+[groups]
+# List of groups to update
+group_list = None
+
+# The types of group packages to install
+group_package_types = mandatory, default
+
+[base]
+# This section overrides yum.conf
+
+# Use this to filter Yum core messages
+# -4: critical
+# -3: critical+errors
+# -2: critical+errors+warnings (default)
+debuglevel = -2
+
+# skip_broken = True
+mdpolicy = group:main
+
+# Uncomment to auto-import new gpg keys (dangerous)
+# assumeyes = True

--- a/templates/yum-cron.conf.j2
+++ b/templates/yum-cron.conf.j2
@@ -1,0 +1,82 @@
+# {{ ansible_managed }}
+[commands]
+#  What kind of update to use:
+# default                            = yum upgrade
+# security                           = yum --security upgrade
+# security-severity:Critical         = yum --sec-severity=Critical upgrade
+# minimal                            = yum --bugfix update-minimal
+# minimal-security                   = yum --security update-minimal
+# minimal-security-severity:Critical =  --sec-severity=Critical update-minimal
+update_cmd = {{ rhbase_yum_cron_update_level }}
+
+# Whether a message should be emitted when updates are available,
+# were downloaded, or applied.
+update_messages = {{ rhbase_yum_cron_update_messages }}
+
+# Whether updates should be downloaded when they are available.
+download_updates = {{ rhbase_yum_cron_download_updates }}
+
+# Whether updates should be applied when they are available.  Note
+# that download_updates must also be yes for the update to be applied.
+apply_updates = {{ rhbase_yum_cron_install_updates }}
+
+# Maximum amout of time to randomly sleep, in minutes.  The program
+# will sleep for a random amount of time between 0 and random_sleep
+# minutes before running.  This is useful for e.g. staggering the
+# times that multiple systems will access update servers.  If
+# random_sleep is 0 or negative, the program will run immediately.
+# 6*60 = 360
+random_sleep = {{ rhbase_yum_cron_sleep_time }}
+
+
+[emitters]
+# Name to use for this system in messages that are emitted.  If
+# system_name is None, the hostname will be used.
+system_name = {{ rhbase_yum_cron_system_name }}
+
+# How to send messages.  Valid options are stdio and email.  If
+# emit_via includes stdio, messages will be sent to stdout; this is useful
+# to have cron send the messages.  If emit_via includes email, this
+# program will send email itself according to the configured options.
+# If emit_via is None or left blank, no messages will be sent.
+emit_via = {{ rhbase_yum_cron_message_protocol }}
+
+# The width, in characters, that messages that are emitted should be
+# formatted to.
+output_width = 80
+
+
+[email]
+# The address to send email messages from.
+# NOTE: 'localhost' will be replaced with the value of system_name.
+email_from = {{ rhbase_yum_cron_email_from }}
+
+# List of addresses to send messages to.
+email_to = {{ rhbase_yum_cron_email_to }}
+
+# Name of the host to connect to to send email messages.
+email_host = {{ rhbase_yum_cron_email_host }}
+
+
+[groups]
+# NOTE: This only works when group_command != objects, which is now the default
+# List of groups to update
+group_list = None
+
+# The types of group packages to install
+group_package_types = mandatory, default
+
+[base]
+# This section overrides yum.conf
+
+# Use this to filter Yum core messages
+# -4: critical
+# -3: critical+errors
+# -2: critical+errors+warnings (default)
+debuglevel = -2
+
+# skip_broken = True
+mdpolicy = group:main
+
+# Uncomment to auto-import new gpg keys (dangerous)
+# assumeyes = True


### PR DESCRIPTION
This will enable automatic updates using yum-cron
 - The option can be enabled and is disabled by default
 - When enabled this will be automatically configured using defaults but can be overwritten using vars in the playbook