### PR TITLE
For each user make sure specified groups exist before attempting to add them

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,3 +130,4 @@ BSD
 - Bert Van Vreckem (maintainer)
 - [Jeroen De Meerleer](https://github.com/JeroenED)
 - [Sebastien Nussbaum](https://github.com/SebaNuss)
+- [Tomas Dabašinskas](https://github.com/T0MASD)

--- a/tasks/users.yml
+++ b/tasks/users.yml
@@ -2,11 +2,19 @@
 #
 # Create groups and users on the system
 ---
+- name: Users | Process groups
+  set_fact:
+    rhbase_user_groups: "{{ rhbase_user_groups }} + {{ item.groups }}"
+  with_items: "{{ rhbase_users }}"
+  tags:
+    - rhbase
+    - users
+
 - name: Users | Add groups
   group:
     name: "{{ item }}"
     state: present
-  with_items: "{{ rhbase_user_groups }}"
+  with_items: "{{ rhbase_user_groups | unique }}"
   tags:
     - rhbase
     - users


### PR DESCRIPTION
Thanks for the nice tool to setup base rh system! 

Currently when I create a new user with group `dummy`, which doesn't exist on the system:
```
    rhbase_users:
      - name: tomas
        groups:
          - share
          - dummy
        shell: "/sbin/nologin"
```
I'm getting an error:
```
failed: [192.168.100.2] (item={'name': 'tomas', 'groups': ['share', 'dummy'], 'shell': '/sbin/nologin'}) => {"changed": false, "item": {"groups": ["share", "dummy"], "name": "tomas", "shell": "/sbin/nologin"}, "msg": "Group dummy does not exist"}
```
The fix adds task `Process groups`, which loops over all users finding groups and extends `rhbase_user_groups` array. This results in groups being added as part of `Add groups` task.
Due to the way user groups are added to `rhbase_user_groups` array, it's necessary to skip duplicate groups hence `Add groups` task applies `unique` filter on `rhbase_user_groups` 

I'm not sure if tests are necessary here, please let me know if I should update those.
Please feel free to suggest other ways of extending `rhbase_user_groups` in `Process groups` task to ensure duplicates are not added. I think using `unique` filter in  `Add groups` task is good idea regardless.