### PR TITLE
Added dnf-automatic for fedora machines

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -13,6 +13,15 @@ rhbase_repo_exclude_from_update: []
 rhbase_repositories: []
 rhbase_update: false
 
+rhbase_repo_update_type: default
+rhbase_repo_random_sleep: 360
+rhbase_repo_updates_download: yes
+rhbase_repo_updates_apply: no
+rhbase_repo_emit_via: stdio
+rhbase_repo_email_from: root@localhost  
+rhbase_repo_email_to: root 
+rhbase_repo_email_host: localhost
+
 # Configuration
 rhbase_override_firewalld_zones: false
 rhbase_hosts_entry: false

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -93,7 +93,7 @@
     - rhbase
     - install
 
-- name: Install | Automatic updater 
+- name: Install | Automatic updates ({{ rhbase_package_manager_automatic_updates }})
   package:
     name: "{{ item }}"
     state: installed
@@ -101,6 +101,17 @@
   tags:
     - rhbase
     - install
+
+- name: Install | Configuration ({{ rhbase_package_manager_automatic_updates }})
+  template:
+    src: etc_{{ rhbase_package_manager }}_{{ rhbase_package_manager_automatic_updates }}.conf.j2
+    dest: "{{ rhbase_package_manager_automatic_updates_config }}"
+    owner: root
+    group: root
+    mode: 0644
+  tags:
+    - rhbase
+    - install    
     
 - name: Install | Ensure yum-cron is running and enabled on boot.
   service: 

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -92,18 +92,19 @@
   tags:
     - rhbase
     - install
-    
-- name: Install | Install yum-cron.
+
+- name: Install | Automatic updater 
   package:
-    name: yum-cron
-    state: present
+    name: "{{ item }}"
+    state: installed
+  with_items: "{{ rhbase_package_manager_automatic_updates }}"
   tags:
     - rhbase
     - install
-
+    
 - name: Install | Ensure yum-cron is running and enabled on boot.
   service: 
-    name: yum-cron
+    name: "{{ rhbase_package_manager_automatic_updates }}"
     state: started
     enabled: yes
   tags:

--- a/templates/etc_dnf_dnf-automatic.conf.j2
+++ b/templates/etc_dnf_dnf-automatic.conf.j2
@@ -1,0 +1,81 @@
+[commands]
+#  What kind of upgrade to perform:
+# default                            = all available upgrades
+# security                           = only the security upgrades
+upgrade_type = {{ rhbase_repo_update_type }}
+random_sleep = {{ rhbase_repo_random_sleep }}
+
+# To just receive updates use dnf-automatic-notifyonly.timer
+
+# Whether updates should be downloaded when they are available, by
+# dnf-automatic.timer. notifyonly.timer, download.timer and
+# install.timer override this setting.
+download_updates = {{ rhbase_repo_updates_download }}
+
+# Whether updates should be applied when they are available, by
+# dnf-automatic.timer. notifyonly.timer, download.timer and
+# install.timer override this setting.
+apply_updates = {{ rhbase_repo_updates_apply }}
+
+
+[emitters]
+# Name to use for this system in messages that are emitted.  Default is the
+# hostname.
+system_name = {{ ansible_hostname }}
+
+# How to send messages.  Valid options are stdio, email and motd.  If
+# emit_via includes stdio, messages will be sent to stdout; this is useful
+# to have cron send the messages.  If emit_via includes email, this
+# program will send email itself according to the configured options.
+# If emit_via includes motd, /etc/motd file will have the messages. if
+# emit_via includes command_email, then messages will be send via a shell
+# command compatible with sendmail.
+# Default is email,stdio.
+# If emit_via is None or left blank, no messages will be sent.
+emit_via = {{ rhbase_repo_emit_via }}
+
+
+[email]
+# The address to send email messages from.
+email_from = {{ rhbase_repo_email_from }}
+
+# List of addresses to send messages to.
+email_to = {{ rhbase_repo_email_to }}
+
+# Name of the host to connect to to send email messages.
+email_host = {{ rhbase_repo_email_host }}
+
+
+[command]
+# The shell command to execute. This is a Python format string, as used in
+# str.format(). The format function will pass a shell-quoted argument called
+# `body`.
+# command_format = "cat"
+
+# The contents of stdin to pass to the command. It is a format string with the
+# same arguments as `command_format`.
+# stdin_format = "{body}"
+
+
+[command_email]
+# The shell command to use to send email. This is a Python format string,
+# as used in str.format(). The format function will pass shell-quoted arguments
+# called body, subject, email_from, email_to.
+# command_format = "mail -s {subject} -r {email_from} {email_to}"
+
+# The contents of stdin to pass to the command. It is a format string with the
+# same arguments as `command_format`.
+# stdin_format = "{body}"
+
+# The address to send email messages from.
+email_from = root@example.com
+
+# List of addresses to send messages to.
+email_to = root
+
+
+[base]
+# This section overrides dnf.conf
+
+# Use this to filter DNF core messages
+debuglevel = 1

--- a/templates/etc_yum_yum-cron.conf.j2
+++ b/templates/etc_yum_yum-cron.conf.j2
@@ -1,0 +1,81 @@
+[commands]
+#  What kind of update to use:
+# default                            = yum upgrade
+# security                           = yum --security upgrade
+# security-severity:Critical         = yum --sec-severity=Critical upgrade
+# minimal                            = yum --bugfix update-minimal
+# minimal-security                   = yum --security update-minimal
+# minimal-security-severity:Critical =  --sec-severity=Critical update-minimal
+update_cmd = {{ rhbase_repo_update_type }}
+
+# Whether a message should be emitted when updates are available,
+# were downloaded, or applied.
+update_messages = yes
+
+# Whether updates should be downloaded when they are available.
+download_updates = {{ rhbase_repo_updates_download }}
+
+# Whether updates should be applied when they are available.  Note
+# that download_updates must also be yes for the update to be applied.
+apply_updates = {{ rhbase_repo_updates_apply }}
+
+# Maximum amout of time to randomly sleep, in minutes.  The program
+# will sleep for a random amount of time between 0 and random_sleep
+# minutes before running.  This is useful for e.g. staggering the
+# times that multiple systems will access update servers.  If
+# random_sleep is 0 or negative, the program will run immediately.
+# 6*60 = 360
+random_sleep = {{ rhbase_repo_random_sleep }}
+
+
+[emitters]
+# Name to use for this system in messages that are emitted.  If
+# system_name is None, the hostname will be used.
+system_name = {{ ansible_hostname }}
+
+# How to send messages.  Valid options are stdio and email.  If
+# emit_via includes stdio, messages will be sent to stdout; this is useful
+# to have cron send the messages.  If emit_via includes email, this
+# program will send email itself according to the configured options.
+# If emit_via is None or left blank, no messages will be sent.
+emit_via = {{ rhbase_repo_emit_via }}
+
+# The width, in characters, that messages that are emitted should be
+# formatted to.
+output_width = 80
+
+
+[email]
+# The address to send email messages from.
+# NOTE: 'localhost' will be replaced with the value of system_name.
+email_from = {{ rhbase_repo_email_from }}
+
+# List of addresses to send messages to.
+email_to = {{ rhbase_repo_email_to }}
+
+# Name of the host to connect to to send email messages.
+email_host = {{ rhbase_repo_email_host }}
+
+
+[groups]
+# NOTE: This only works when group_command != objects, which is now the default
+# List of groups to update
+group_list = None
+
+# The types of group packages to install
+group_package_types = mandatory, default
+
+[base]
+# This section overrides yum.conf
+
+# Use this to filter Yum core messages
+# -4: critical
+# -3: critical+errors
+# -2: critical+errors+warnings (default)
+debuglevel = -2
+
+# skip_broken = True
+mdpolicy = group:main
+
+# Uncomment to auto-import new gpg keys (dangerous)
+# assumeyes = True

--- a/vars/Fedora.yml
+++ b/vars/Fedora.yml
@@ -14,3 +14,4 @@ rhbase_dependencies:
 rhbase_package_manager: dnf
 rhbase_package_manager_configuration: /etc/dnf/dnf.conf
 
+rhbase_package_manager_automatic_updates: dnf-automatic

--- a/vars/Fedora.yml
+++ b/vars/Fedora.yml
@@ -9,9 +9,10 @@ rhbase_dependencies:
   - libselinux-python
   - libsemanage-python
   - firewalld
-  - python-firewall
+  - python3-firewall
 
 rhbase_package_manager: dnf
 rhbase_package_manager_configuration: /etc/dnf/dnf.conf
 
 rhbase_package_manager_automatic_updates: dnf-automatic
+rhbase_package_manager_automatic_updates_config: /etc/dnf/automatic.conf

--- a/vars/RedHat.yml
+++ b/vars/RedHat.yml
@@ -12,3 +12,5 @@ rhbase_dependencies:
 
 rhbase_package_manager: yum
 rhbase_package_manager_configuration: /etc/yum.conf
+
+rhbase_package_manager_automatic_updates: yum-cron

--- a/vars/RedHat.yml
+++ b/vars/RedHat.yml
@@ -14,3 +14,4 @@ rhbase_package_manager: yum
 rhbase_package_manager_configuration: /etc/yum.conf
 
 rhbase_package_manager_automatic_updates: yum-cron
+rhbase_package_manager_automatic_updates_config: /etc/yum/yum-cron.conf


### PR DESCRIPTION
So I noticed that fedora machines would install yum-cron as well, despite using dnf and not yum as the package manager, so I decided to split it up, so that fedora clients would use dnf automatic. I'll be adding a way to configure the config files of both of those as well soon