### PR TITLE
Added AllowGroups in sshd_config

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,9 +37,10 @@ No specific requirements
 | `rhbase_selinux_booleans`         | []              | List of SELinux booleans to be set to on, e.g. httpd_can_network_connect                                              |
 | `rhbase_ssh_key`                  | -               | The public SSH key for the admin user that allows her to log in without a password. The user should exist.            |
 | `rhbase_ssh_user`                 | -               | The name of the user that will manage this machine. The SSH key will be installed into the user's home directory.(3)  |
+| `rhbase_ssh_allow_groups`         | []              | List of groups allowed to ssh. When enabled, only users in these groups are allowed ssh access. (4)                   |
 | `rhbase_start_services`           | []              | List of services that should be running and enabled.                                                                  |
 | `rhbase_stop_services`            | []              | List of services that should **not** be running                                                                       |
-| `rhbase_tz`                       | :/etc/localtime | Sets the `$TZ` environment variable (4)                                                                               |
+| `rhbase_tz`                       | :/etc/localtime | Sets the `$TZ` environment variable (5)                                                                               |
 | `rhbase_update`                   | false           | When set, a package update will be performed.                                                                         |
 | `rhbase_user_groups`              | []              | List of user groups that should be present.                                                                           |
 | `rhbase_users`                    | []              | List of dicts specifying users that should be present. See below for an example.                                      |
@@ -52,7 +53,9 @@ No specific requirements
 
 (3) Setting the variable `rhbase_ssh_user` does not actually create a user, but installs the `rhbase_ssh_key` in that user's home directory (`~/.ssh/authorized_keys`). Consequently, `rhbase_ssh_user` should be the name of an existing user, specified in `rhbase_users`.
 
-(4) setting `$TZ` variable may reduce the number of system calls. See <https://blog.packagecloud.io/eng/2017/02/21/set-environment-variable-save-thousands-of-system-calls/>
+(4) If you use this role with Vagrant and set the variable `rhbase_ssh_allow_groups`, you need to define the `vagrant` group in the list of `rhbase_ssh_allow_groups`.
+
+(5) Setting `$TZ` variable may reduce the number of system calls. See <https://blog.packagecloud.io/eng/2017/02/21/set-environment-variable-save-thousands-of-system-calls/>
 
 ### Enabling repositories
 
@@ -130,3 +133,4 @@ BSD
 - Bert Van Vreckem (maintainer)
 - [Jeroen De Meerleer](https://github.com/JeroenED)
 - [Sebastien Nussbaum](https://github.com/SebaNuss)
+- [Sven de Windt](https://github.com/svendewindt)

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -33,3 +33,4 @@ rhbase_selinux_booleans: []
 # Users
 rhbase_users: []
 rhbase_user_groups: []
+rhbase_ssh_allow_groups: []

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -10,3 +10,8 @@
   service:
     name: firewalld
     state: restarted
+
+- name: restart sshd
+  service:
+    name: sshd
+    state: restarted

--- a/tasks/admin.yml
+++ b/tasks/admin.yml
@@ -24,3 +24,14 @@
     - rhbase
     - admin
 
+- name: Admin | Make sure only these groups can ssh
+  lineinfile:
+    dest: /etc/ssh/sshd_config
+    state: present
+    create: yes
+    regexp: '^AllowGroups'
+    line: "AllowGroups={{ ' '.join(rhbase_ssh_allow_groups) }}"
+  notify: restart sshd
+  tags: 
+    - rhbase
+    - admin


### PR DESCRIPTION
This role is used to setup a basic instance, including an admin user with ssh key. 
We can increase security by limiting the number of users allowed to ssh to this instance by adding the `AllowGroups` list to the ssh config in `/etc/ssh/sshd_config`.

To facilitate this, I also added a handler to restart the sshd deamon after a change. 

Users need to take care that if they set this variable and use Vagrant to provision the machine, they must add the group `vagrant` to the `AllowGroups`.  If not, Vagrant is no longer able to ssh to the instance.