### PR TITLE
Set SSH protocol version by default to 2

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,10 +39,11 @@ No specific requirements
 | `rhbase_selinux_state`                    | enforcing       | The default SELinux state for the system. Just [leave this as is](http://stopdisablingselinux.com/).                  |
 | `rhbase_ssh_allow_groups`                 | []              | List of groups allowed to ssh. When enabled, only users in these groups are allowed ssh access. (4)                   |
 | `rhbase_ssh_ignorerhosts`                 | 'yes'           | Specifies that .rhosts and .shosts files will not be used in RhostsRSAAuthentication or HostbasedAuthentication.      |
-| `rhbase_ssh_hostbasedauthentication`      | 'no'            | Controls host based authentication.                                                                                   |
+| `rhbase_ssh_hostbasedauthentication`      | 'no'            | Wheter to allow host based authentication.                                                                            |
 | `rhbase_ssh_key`                          | -               | The public SSH key for the admin user that allows her to log in without a password. The user should exist.            |
-| `rhbase_ssh_permitemptypasswords`         | 'no'            | Disallows empty passwords to logon.                                                                                   |
+| `rhbase_ssh_permitemptypasswords`         | 'no'            | Wheter to allow empty passwords to logon.                                                                             |
 | `rhbase_ssh_protocol_version`             | 2               | Sets the SSH protocol version.                                                                                        |
+| `rhbase_ssh_rhostsrsaauthentication`      | 'no'            | Wheter to allow rhosts RSA authentication                                                                             |
 | `rhbase_ssh_user`                         | -               | The name of the user that will manage this machine. The SSH key will be installed into the user's home directory.(3)  |
 | `rhbase_start_services`                   | []              | List of services that should be running and enabled.                                                                  |
 | `rhbase_stop_services`                    | []              | List of services that should **not** be running                                                                       |

--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ No specific requirements
 | `rhbase_selinux_state`                    | enforcing       | The default SELinux state for the system. Just [leave this as is](http://stopdisablingselinux.com/).                  |
 | `rhbase_ssh_allow_groups`                 | []              | List of groups allowed to ssh. When enabled, only users in these groups are allowed ssh access. (4)                   |
 | `rhbase_ssh_key`                          | -               | The public SSH key for the admin user that allows her to log in without a password. The user should exist.            |
+| `rhbase_ssh_ignorerhosts`                 | 'yes'           | Specifies that .rhosts and .shosts files will not be used in RhostsRSAAuthentication or HostbasedAuthentication.      |
 | `rhbase_ssh_permitemptypasswords`         | 'no'            | Disallows empty passwords to logon.                                                                                   |
 | `rhbase_ssh_protocol_version`             | 2               | Sets the SSH protocol version.                                                                                        |
 | `rhbase_ssh_user`                         | -               | The name of the user that will manage this machine. The SSH key will be installed into the user's home directory.(3)  |

--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ No specific requirements
 | `rhbase_selinux_state`                    | enforcing       | The default SELinux state for the system. Just [leave this as is](http://stopdisablingselinux.com/).                  |
 | `rhbase_ssh_allow_groups`                 | []              | List of groups allowed to ssh. When enabled, only users in these groups are allowed ssh access. (4)                   |
 | `rhbase_ssh_key`                          | -               | The public SSH key for the admin user that allows her to log in without a password. The user should exist.            |
+|  rhbase_ssh_protocol			    | 2               | Sets the SSH protocol.                                                                                                |
 | `rhbase_ssh_user`                         | -               | The name of the user that will manage this machine. The SSH key will be installed into the user's home directory.(3)  |
 | `rhbase_start_services`                   | []              | List of services that should be running and enabled.                                                                  |
 | `rhbase_stop_services`                    | []              | List of services that should **not** be running                                                                       |

--- a/README.md
+++ b/README.md
@@ -39,7 +39,8 @@ No specific requirements
 | `rhbase_selinux_state`                    | enforcing       | The default SELinux state for the system. Just [leave this as is](http://stopdisablingselinux.com/).                  |
 | `rhbase_ssh_allow_groups`                 | []              | List of groups allowed to ssh. When enabled, only users in these groups are allowed ssh access. (4)                   |
 | `rhbase_ssh_key`                          | -               | The public SSH key for the admin user that allows her to log in without a password. The user should exist.            |
-| `rhbase_ssh_protocol_version`             | 2               | Sets the SSH protocol version.                                                                                                |
+| `rhbase_permitemptypasswords`             | 'no'            | Disallows empty passwords to logon.                                                                                   |
+| `rhbase_ssh_protocol_version`             | 2               | Sets the SSH protocol version.                                                                                        |
 | `rhbase_ssh_user`                         | -               | The name of the user that will manage this machine. The SSH key will be installed into the user's home directory.(3)  |
 | `rhbase_start_services`                   | []              | List of services that should be running and enabled.                                                                  |
 | `rhbase_stop_services`                    | []              | List of services that should **not** be running                                                                       |

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ No specific requirements
 | `rhbase_selinux_state`                    | enforcing       | The default SELinux state for the system. Just [leave this as is](http://stopdisablingselinux.com/).                  |
 | `rhbase_ssh_allow_groups`                 | []              | List of groups allowed to ssh. When enabled, only users in these groups are allowed ssh access. (4)                   |
 | `rhbase_ssh_key`                          | -               | The public SSH key for the admin user that allows her to log in without a password. The user should exist.            |
-| `rhbase_permitemptypasswords`             | 'no'            | Disallows empty passwords to logon.                                                                                   |
+| `rhbase_sshpermitemptypasswords`          | 'no'            | Disallows empty passwords to logon.                                                                                   |
 | `rhbase_ssh_protocol_version`             | 2               | Sets the SSH protocol version.                                                                                        |
 | `rhbase_ssh_user`                         | -               | The name of the user that will manage this machine. The SSH key will be installed into the user's home directory.(3)  |
 | `rhbase_start_services`                   | []              | List of services that should be running and enabled.                                                                  |

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ No specific requirements
 | `rhbase_selinux_state`                    | enforcing       | The default SELinux state for the system. Just [leave this as is](http://stopdisablingselinux.com/).                  |
 | `rhbase_ssh_allow_groups`                 | []              | List of groups allowed to ssh. When enabled, only users in these groups are allowed ssh access. (4)                   |
 | `rhbase_ssh_key`                          | -               | The public SSH key for the admin user that allows her to log in without a password. The user should exist.            |
-|  rhbase_ssh_protocol			    | 2               | Sets the SSH protocol.                                                                                                |
+| `rhbase_ssh_protocol_version`             | 2               | Sets the SSH protocol version.                                                                                                |
 | `rhbase_ssh_user`                         | -               | The name of the user that will manage this machine. The SSH key will be installed into the user's home directory.(3)  |
 | `rhbase_start_services`                   | []              | List of services that should be running and enabled.                                                                  |
 | `rhbase_stop_services`                    | []              | List of services that should **not** be running                                                                       |

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ No specific requirements
 | `rhbase_selinux_state`                    | enforcing       | The default SELinux state for the system. Just [leave this as is](http://stopdisablingselinux.com/).                  |
 | `rhbase_ssh_allow_groups`                 | []              | List of groups allowed to ssh. When enabled, only users in these groups are allowed ssh access. (4)                   |
 | `rhbase_ssh_key`                          | -               | The public SSH key for the admin user that allows her to log in without a password. The user should exist.            |
-| `rhbase_sshpermitemptypasswords`          | 'no'            | Disallows empty passwords to logon.                                                                                   |
+| `rhbase_ssh_permitemptypasswords`         | 'no'            | Disallows empty passwords to logon.                                                                                   |
 | `rhbase_ssh_protocol_version`             | 2               | Sets the SSH protocol version.                                                                                        |
 | `rhbase_ssh_user`                         | -               | The name of the user that will manage this machine. The SSH key will be installed into the user's home directory.(3)  |
 | `rhbase_start_services`                   | []              | List of services that should be running and enabled.                                                                  |

--- a/README.md
+++ b/README.md
@@ -38,8 +38,9 @@ No specific requirements
 | `rhbase_selinux_booleans`                 | []              | List of SELinux booleans to be set to on, e.g. httpd_can_network_connect                                              |
 | `rhbase_selinux_state`                    | enforcing       | The default SELinux state for the system. Just [leave this as is](http://stopdisablingselinux.com/).                  |
 | `rhbase_ssh_allow_groups`                 | []              | List of groups allowed to ssh. When enabled, only users in these groups are allowed ssh access. (4)                   |
-| `rhbase_ssh_key`                          | -               | The public SSH key for the admin user that allows her to log in without a password. The user should exist.            |
 | `rhbase_ssh_ignorerhosts`                 | 'yes'           | Specifies that .rhosts and .shosts files will not be used in RhostsRSAAuthentication or HostbasedAuthentication.      |
+| `rhbase_ssh_hostbasedauthentication`      | 'no'            | Controls host based authentication.                                                                                   |
+| `rhbase_ssh_key`                          | -               | The public SSH key for the admin user that allows her to log in without a password. The user should exist.            |
 | `rhbase_ssh_permitemptypasswords`         | 'no'            | Disallows empty passwords to logon.                                                                                   |
 | `rhbase_ssh_protocol_version`             | 2               | Sets the SSH protocol version.                                                                                        |
 | `rhbase_ssh_user`                         | -               | The name of the user that will manage this machine. The SSH key will be installed into the user's home directory.(3)  |

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -28,6 +28,7 @@ rhbase_hosts_entry: false
 rhbase_motd: false
 rhbase_tz: :/etc/localtime
 rhbase_dynamic_motd: false
+rhbase_ssh_hostbasedauthentication: 'no'
 rhbase_ssh_ignorerhosts: 'yes'
 rhbase_ssh_permitemptypasswords: 'no'
 rhbase_ssh_protocol_version: 2

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -28,7 +28,7 @@ rhbase_hosts_entry: false
 rhbase_motd: false
 rhbase_tz: :/etc/localtime
 rhbase_dynamic_motd: false
-rhbase_ssh_protocol: 2
+rhbase_ssh_protocol_version 2
 
 # Services
 rhbase_start_services: []

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -28,6 +28,7 @@ rhbase_hosts_entry: false
 rhbase_motd: false
 rhbase_tz: :/etc/localtime
 rhbase_dynamic_motd: false
+rhbase_ssh_ignorerhosts: 'yes'
 rhbase_ssh_permitemptypasswords: 'no'
 rhbase_ssh_protocol_version: 2
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -28,6 +28,7 @@ rhbase_hosts_entry: false
 rhbase_motd: false
 rhbase_tz: :/etc/localtime
 rhbase_dynamic_motd: false
+rhbase_ssh_permitemptypasswords: 'no'
 rhbase_ssh_protocol_version: 2
 
 # Services

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -28,7 +28,7 @@ rhbase_hosts_entry: false
 rhbase_motd: false
 rhbase_tz: :/etc/localtime
 rhbase_dynamic_motd: false
-rhbase_ssh_protocol_version 2
+rhbase_ssh_protocol_version: 2
 
 # Services
 rhbase_start_services: []

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -32,6 +32,7 @@ rhbase_ssh_hostbasedauthentication: 'no'
 rhbase_ssh_ignorerhosts: 'yes'
 rhbase_ssh_permitemptypasswords: 'no'
 rhbase_ssh_protocol_version: 2
+rhbase_ssh_rhostsrsaauthentication: 'no'
 
 # Services
 rhbase_start_services: []

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -28,6 +28,7 @@ rhbase_hosts_entry: false
 rhbase_motd: false
 rhbase_tz: :/etc/localtime
 rhbase_dynamic_motd: false
+rhbase_ssh_protocol: 2
 
 # Services
 rhbase_start_services: []

--- a/tasks/config.yml
+++ b/tasks/config.yml
@@ -81,7 +81,6 @@
     - rhbase
     - config
 
-# Configure protocol version for SSH
 - name: Config | Set protocol version for SSH
   lineinfile:
     dest: /etc/ssh/sshd_config
@@ -89,6 +88,19 @@
     create: yes
     regexp: '^Protocol'
     line: "Protocol {{rhbase_ssh_protocol_version}}"
+  notify: restart sshd
+  tags:
+    - rhbase
+    - config
+
+- name: Config | Set PermitEmptyPasswords
+  lineinfile:
+    dest: /etc/ssh/sshd_config
+    state: present
+    create: yes
+    regexp: '^PermitEmptyPasswords'
+    insertafter: '^#PermitEmptyPasswords'
+    line: "PermitEmptyPasswords {{ rhbase_ssh_permitemptypasswords }}"
   notify: restart sshd
   tags:
     - rhbase

--- a/tasks/config.yml
+++ b/tasks/config.yml
@@ -118,3 +118,16 @@
   tags:
     - rhbase
     - config
+
+- name: Config | Set HostbasedAuthentication
+  lineinfile:
+    dest: /etc/ssh/sshd_config
+    state: present
+    create: yes
+    regexp: '^HostbasedAuthentication'
+    insertafter: '^#HostbasedAuthentication'
+    line: "HostbasedAuthentication {{ rhbase_ssh_hostbasedauthentication }}"
+  notify: restart sshd
+  tags:
+    - rhbase
+    - config

--- a/tasks/config.yml
+++ b/tasks/config.yml
@@ -88,7 +88,7 @@
     state: present
     create: yes
     regexp: '^Protocol'
-    line: "Protocol {{rhbase_ssh_protocol}}"
+    line: "Protocol {{rhbase_ssh_protocol_version}}"
   notify: restart sshd
   tags:
     - rhbase

--- a/tasks/config.yml
+++ b/tasks/config.yml
@@ -131,3 +131,16 @@
   tags:
     - rhbase
     - config
+
+- name: Config | Set RhostsRSAAuthentication
+  lineinfile:
+    dest: /etc/ssh/sshd_config
+    state: present
+    create: yes
+    regexp: '^RhostsRSAAuthentication'
+    insertafter: '^#RhostsRSAAuthentication'
+    line: "RhostsRSAAuthentication {{ rhbase_ssh_rhostsrsaauthentication }}"
+  notify: restart sshd
+  tags:
+    - rhbase
+    - config

--- a/tasks/config.yml
+++ b/tasks/config.yml
@@ -80,3 +80,16 @@
   tags:
     - rhbase
     - config
+
+# Configure protocol version for SSH
+- name: Config | Set protocol version for SSH
+  lineinfile:
+    dest: /etc/ssh/sshd_config
+    state: present
+    create: yes
+    regexp: '^Protocol'
+    line: "Protocol {{rhbase_ssh_protocol}}"
+  notify: restart sshd
+  tags:
+    - rhbase
+    - config

--- a/tasks/config.yml
+++ b/tasks/config.yml
@@ -105,3 +105,16 @@
   tags:
     - rhbase
     - config
+
+- name: Config | Set IgnoreRhosts
+  lineinfile:
+    dest: /etc/ssh/sshd_config
+    state: present
+    create: yes
+    regexp: '^IgnoreRhosts'
+    insertafter: '^#IgnoreRhosts'
+    line: "IgnoreRhosts {{ rhbase_ssh_ignorerhosts }}"
+  notify: restart sshd
+  tags:
+    - rhbase
+    - config


### PR DESCRIPTION
Based on the Azure OMS security baseline for SSH:

* Protocol should be 2
* PermitEmptyPasswords should be no
* IgnoreRhosts should be yes
* HostbasedAuthentication should be no